### PR TITLE
Added implode method

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,3 +5,4 @@ parameters:
 	ignoreErrors:
 	    - '#Result of method [a-zA-Z]+::[a-zA-Z]+\(\) \(void\) is used.#'
 	    - '#Method [a-zA-Z\\]+::[a-zA-Z]+\(\) should return bool but returns void.#'
+	reportUnmatchedIgnoredErrors: false

--- a/src/Collections/CollectionAbstract.php
+++ b/src/Collections/CollectionAbstract.php
@@ -218,4 +218,17 @@ abstract class CollectionAbstract implements CollectionContract
     {
         $this->items->rewind();
     }
+
+    /**
+     * Implodes the collection items.
+     *
+     * @param string   $separator
+     * @param \Closure $callback
+     *
+     * @return string
+     */
+    public function implode($separator, $callback)
+    {
+        return implode($separator, $this->map($callback)->all());
+    }
 }

--- a/tests/Columns/ColumnCollectionTest.php
+++ b/tests/Columns/ColumnCollectionTest.php
@@ -143,4 +143,20 @@ class ColumnCollectionTest extends TestCase
             $columnBirthday,
         ], $columnCollection->getSortableColumns()->all());
     }
+
+    /** @test */
+    public function itCanBeImploded()
+    {
+        $columnCollection = new ColumnCollection();
+
+        $columnCollection->add(new Column('id', 'Id'));
+        $columnCollection->add(new Column('email', 'Email'));
+        $columnCollection->add(new Column('role', 'Role'));
+
+        $implodedCollection = $columnCollection->implode(',', function ($column) {
+            return $column->getLabel();
+        });
+
+        $this->assertEquals('Id,Email,Role', $implodedCollection);
+    }
 }


### PR DESCRIPTION
This implementation is directly taken from https://github.com/query-grid/query-grid/issues/8 issue.

Now all `CollectionAbstract` children have an `implode` method available.

A call in a `ColumnCollection` should be as the following:

```php
$columnCollection->implode(',', function ($column) {
    return $column->getLabel();
});
```

And, in a `RowCollection`:

```php
$rowCollection->implode("\n", function ($row) {
    return implode(',', $row);
});
```

Tests are included, but like we don't test abstract classes I made it with the `CollumnCollection` class.